### PR TITLE
Add model option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ AI PR Review analyzes GitHub pull requests and provides detailed feedback using 
 ## Usage
 
 ```bash
-python -m ai_pr_review <repo_owner> <repo_name> <pr_number>
+python -m ai_pr_review [--model MODEL] <repo_owner> <repo_name> <pr_number>
 ```
+Use `--model` to choose the OpenAI model (defaults to `gpt-4.1`).
 
 Example:
 ```bash

--- a/src/ai_pr_review/cli.py
+++ b/src/ai_pr_review/cli.py
@@ -25,6 +25,11 @@ def main(cli_args: list[str] | None = None) -> None:
         action='store_true',
         help='Keep the temporary repository after execution (for debugging)',
     )
+    parser.add_argument(
+        '--model',
+        default='gpt-4.1',
+        help='OpenAI model to use for generating the review',
+    )
 
     args = parser.parse_args(cli_args)
     try:
@@ -33,6 +38,7 @@ def main(cli_args: list[str] | None = None) -> None:
             cast(str, args.repo_name),
             cast(int, args.pr_number),
             cast(bool, args.keep_temp),
+            cast(str, args.model),
         )
         print('\n--- AI PR Review (whatthepatch version) ---')
         print(review_text)

--- a/src/ai_pr_review/review.py
+++ b/src/ai_pr_review/review.py
@@ -7,7 +7,11 @@ from .repo import checkout_pr_head, cleanup_temp_dir, clone_repo_to_temp_dir
 
 
 def review_pr(
-    repo_owner: str, repo_name: str, pr_number: int, keep_temp: bool = False
+    repo_owner: str,
+    repo_name: str,
+    pr_number: int,
+    keep_temp: bool = False,
+    model: str = 'gpt-4.1',
 ) -> str:
     """Generate an AI-based review for the pull request."""
     temp_dir: str | None = None
@@ -25,7 +29,12 @@ def review_pr(
         context_blob = process_pr_context(temp_dir, diff_text)
 
         # Generate PR review using LLM
-        review_text = review_with_llm(pr_title, pr_description, context_blob)
+        review_text = review_with_llm(
+            pr_title,
+            pr_description,
+            context_blob,
+            model=model,
+        )
 
         return review_text
     finally:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,18 @@
+from ai_pr_review.cli import main as cli_main
+
+
+def test_cli_parses_model(monkeypatch):
+    calls = {}
+
+    def fake_review_pr(owner, name, pr_number, keep_temp, model):
+        calls['owner'] = owner
+        calls['name'] = name
+        calls['pr_number'] = pr_number
+        calls['keep_temp'] = keep_temp
+        calls['model'] = model
+        return 'ok'
+
+    monkeypatch.setattr('ai_pr_review.cli.review_pr', fake_review_pr)
+    cli_main(['o', 'r', '1', '--model', 'test-model'])
+
+    assert calls['model'] == 'test-model'


### PR DESCRIPTION
## Summary
- expose a `--model` flag in the CLI to choose the OpenAI model
- thread the model through `review_pr` to `review_with_llm`
- document the new option in the README
- add a simple test ensuring the CLI forwards the model

## Testing
- `uv run ruff check --fix src tests`
- `uv run pytest -q`