### PR TITLE
Defer API key validation to setup

### DIFF
--- a/src/ai_pr_review/llm.py
+++ b/src/ai_pr_review/llm.py
@@ -11,15 +11,19 @@ from .errors import ConfigurationError
 # Load environment variables
 load_dotenv()
 
-# Check for API key and initialize client
-OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
-if not OPENAI_API_KEY:
-    raise ConfigurationError('OPENAI_API_KEY environment variable not set.')
+
+def _get_openai_api_key() -> str:
+    """Return the OpenAI API key from the environment or raise an error."""
+    api_key = os.getenv('OPENAI_API_KEY')
+    if not api_key:
+        raise ConfigurationError('OPENAI_API_KEY environment variable not set.')
+    return api_key
 
 
 def setup_openai_client() -> OpenAI:
     """Set up and return OpenAI client."""
-    return OpenAI(api_key=OPENAI_API_KEY)
+    api_key = _get_openai_api_key()
+    return OpenAI(api_key=api_key)
 
 
 def create_review_prompts(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,6 @@
-import os
 import sys
 from pathlib import Path
 
 # Add the src directory to sys.path for tests
 SRC = Path(__file__).resolve().parents[1] / 'src'
 sys.path.insert(0, str(SRC))
-
-# Ensure tests do not fail due to missing API key
-os.environ.setdefault('OPENAI_API_KEY', 'dummy')

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -20,13 +20,14 @@ def mock_openai_client():
     return client
 
 
-def test_setup_openai_client():
+def test_setup_openai_client(monkeypatch):
     """Test setting up OpenAI client."""
     with patch('ai_pr_review.llm.OpenAI') as mock_openai:
+        monkeypatch.setenv('OPENAI_API_KEY', 'dummy')
         setup_openai_client()
         mock_openai.assert_called_once()
         # Verify API key is passed
-        assert mock_openai.call_args[1]['api_key'] is not None
+        assert mock_openai.call_args[1]['api_key'] == 'dummy'
 
 
 def test_create_review_prompts():

--- a/tests/test_split_modules.py
+++ b/tests/test_split_modules.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 
 import pytest
@@ -10,8 +9,6 @@ from ai_pr_review.repo import clone_repo_to_temp_dir
 
 
 def test_fetch_pr_data_error(monkeypatch):
-    os.environ.setdefault('OPENAI_API_KEY', 'dummy')
-
     def raise_request(*_a, **_kw):
         raise requests.exceptions.RequestException('boom')
 


### PR DESCRIPTION
## Summary
- validate the OpenAI API key when initializing the client
- update tests to set environment variables only where needed

## Testing
- `uv run ruff check --fix src tests`
- `uv run pytest -q`