### PR TITLE
Add two-way sync pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,4 +9,12 @@ repos:
       - id: ruff-check
         types_or: [python, pyi]
         args: [--fix]
+  - repo: local
+    hooks:
+      - id: sync-guidelines
+        name: Sync CLAUDE.md and AGENTS.md
+        entry: scripts/sync_guidelines.py
+        language: system
+        pass_filenames: false
+        always_run: true
         

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,23 @@
 # Repository Guidelines
 
+Use this file for a quick orientation to the repository and as a checklist
+before committing changes.
+
+## Key Directories
+
+- `src/` – The `ai_pr_review` package with all source code.
+- `tests/` – Pytest suite covering the package.
+- `docs/` – Project documentation and design notes.
+- `scripts/` – Utility scripts (e.g. `embed_repo.py` for vendoring code).
+- `vendor/` – Third-party repos embedded here for offline tests and examples.
+
+## Workflow
+- Install the pre-commit hooks with `pre-commit install` to ensure `AGENTS.md` and `CLAUDE.md` stay synchronized and we only commit clean code.
 - Run `uv run ruff check --fix src tests` before committing to ensure code style.
 - Run `uv run pytest -q` to execute the test suite.
 - Run `uv run -m ai_pr_review <repo_owner> <repo_name> <pr_number>` to review a PR.
 - Run `uv run basedpyright` and resolve any reported issues before committing.
+- Run `uv run -m ai_pr_review <repo_owner> <repo_name> <pr_number>` to review a PR.
+
+If any directory layout or workflow step described here changes in a commit or
+PR, update `AGENTS.md` as part of that same change so this file stays accurate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,58 +1,23 @@
-# CLAUDE.md
+# Repository Guidelines
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Use this file for a quick orientation to the repository and as a checklist
+before committing changes.
 
-## Project Overview
+## Key Directories
 
-AI PR Review is a tool that uses AI to review GitHub pull requests. It:
-1. Fetches PR data (diff, metadata) from GitHub's API
-2. Clones the repository to a temporary directory
-3. Extracts context from the changed files and surrounding code
-4. Sends the context to an LLM (currently GPT-4.1) for review
-5. Displays the AI-generated PR review
+- `src/` – The `ai_pr_review` package with all source code.
+- `tests/` – Pytest suite covering the package.
+- `docs/` – Project documentation and design notes.
+- `scripts/` – Utility scripts (e.g. `embed_repo.py` for vendoring code).
+- `vendor/` – Third-party repos embedded here for offline tests and examples.
 
-## Dependencies
+## Workflow
+- Install the pre-commit hooks with `pre-commit install` to ensure `AGENTS.md` and `CLAUDE.md` stay synchronized and we only commit clean code.
+- Run `uv run ruff check --fix src tests` before committing to ensure code style.
+- Run `uv run pytest -q` to execute the test suite.
+- Run `uv run -m ai_pr_review <repo_owner> <repo_name> <pr_number>` to review a PR.
+- Run `uv run basedpyright` and resolve any reported issues before committing.
+- Run `uv run -m ai_pr_review <repo_owner> <repo_name> <pr_number>` to review a PR.
 
-The project uses:
-- Python 3.11+
-- cased-kit: For code context extraction
-- openai: For LLM API access
-- whatthepatch: For parsing git diff format
-- python-dotenv: For environment variable management
-- requests: For GitHub API calls
-
-## Setup and Configuration
-
-1. Copy `.env.example` to `.env` and add:
-   - `OPENAI_API_KEY`: Required for LLM access
-   - `GITHUB_TOKEN`: Optional but recommended for GitHub API access (avoids rate limits)
-
-## Running the Tool
-
-Basic usage:
-```bash
-python main.py <repo_owner> <repo_name> <pr_number>
-```
-
-Example:
-```bash
-python main.py anthropics claude-code 123
-```
-
-Options:
-- `--keep-temp`: Keep the temporary repository clone after execution (useful for debugging)
-
-## Code Architecture
-
-The main components are:
-1. **GitHub PR Data Fetching**: Functions to fetch PR diff and metadata using GitHub API
-2. **Repository Management**: Functions to clone, checkout, and clean up temporary repos
-3. **Context Extraction**: Uses Kit's context assembler and whatthepatch to build context from changes
-4. **LLM Processing**: Formats context with prompts and sends to LLM for review
-
-## Development Notes
-
-- Use Python's virtual environment capabilities for development
-- Install dependencies using a package manager like pip, poetry, or uv
-- The project uses [Kit](https://github.com/cased/kit) for code context extraction
-- PR reviews focus on correctness, clarity, potential bugs, and best practices
+If any directory layout or workflow step described here changes in a commit or
+PR, update `AGENTS.md` as part of that same change so this file stays accurate.

--- a/scripts/sync_guidelines.py
+++ b/scripts/sync_guidelines.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Pre-commit hook to sync AGENTS.md and CLAUDE.md."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+AGENTS_FILE = REPO_ROOT / "AGENTS.md"
+CLAUDE_FILE = REPO_ROOT / "CLAUDE.md"
+
+
+def _run(cmd: list[str]) -> str:
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return result.stdout.strip()
+
+
+def _staged_files() -> set[str]:
+    out = _run(["git", "diff", "--name-only", "--cached"])
+    return set(out.splitlines())
+
+
+def _stage(path: Path) -> None:
+    relative = path.relative_to(REPO_ROOT)
+    subprocess.run(["git", "add", str(relative)], check=True)
+
+
+def _read(path: Path) -> str:
+    return path.read_text()
+
+
+def _sync(src: Path, dest: Path) -> None:
+    dest.write_text(_read(src))
+    _stage(dest)
+    print(f"Synced {src.name} -> {dest.name}")
+
+
+def main() -> int:
+    changed = _staged_files()
+    agent_changed = str(AGENTS_FILE.relative_to(REPO_ROOT)) in changed
+    claude_changed = str(CLAUDE_FILE.relative_to(REPO_ROOT)) in changed
+
+    agent_content = _read(AGENTS_FILE)
+    claude_content = _read(CLAUDE_FILE)
+
+    if agent_changed and claude_changed:
+        if agent_content != claude_content:
+            sys.stderr.write(
+                "Both AGENTS.md and CLAUDE.md changed with different content."
+                " Commit one file at a time to keep them in sync.\n"
+            )
+            return 1
+        return 0
+
+    if agent_changed:
+        if agent_content != claude_content:
+            _sync(AGENTS_FILE, CLAUDE_FILE)
+        return 0
+
+    if claude_changed:
+        if agent_content != claude_content:
+            _sync(CLAUDE_FILE, AGENTS_FILE)
+        return 0
+
+    if agent_content != claude_content:
+        sys.stderr.write(
+            "AGENTS.md and CLAUDE.md differ but neither file was staged."
+            " Please update one file so they match.\n"
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a `sync-guidelines` pre-commit hook to keep `CLAUDE.md` and `AGENTS.md` identical
- enable the hook in `.pre-commit-config.yaml`
- update the repository guidelines with key directories and the workflow checklist

## Testing
- `uv run ruff check --fix src tests`
- `uv run pytest -q`
- `uv run basedpyright`
- `uv run pre-commit run --files AGENTS.md CLAUDE.md scripts/sync_guidelines.py .pre-commit-config.yaml`
